### PR TITLE
typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Display help message for more CLI options:
 ```
 from honeydb import api
 honeydb = api.Client('api_id', 'api_key')
-print(honeydb.bad-hosts())
+print(honeydb.bad_hosts())
 ```


### PR DESCRIPTION
there is a typo in the read me on how to call bad_hosts()